### PR TITLE
refactor: some comments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,6 +345,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pin-project"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -458,6 +478,7 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "paste",
+ "pin-project",
  "prometheus",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,21 +10,21 @@ lazy_static = "1.4"
 num_cpus = "1.16"
 once_cell = "1.18"
 paste = "1.0"
+pin-project = "1.1"
 prometheus = { version = "0.13.3", features = ["process"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 snafu = "0.8"
+sysinfo = "0.30.13"
 tokio = { version = "1.36", features = ["full"] }
-tokio-util = { version = "0.7", features = ["io-util", "compat"] }
 tokio-metrics = "0.3"
 tokio-metrics-collector = { git = "https://github.com/MichaelScofield/tokio-metrics-collector.git", rev = "89d692d5753d28564a7aac73c6ac5aba22243ba0" }
+tokio-util = { version = "0.7", features = ["io-util", "compat"] }
 tracing = "0.1.40"
-sysinfo = "0.30.13"
 
 # common-error.workspace = true
 # common-macro.workspace = true
 # common-telemetry.workspace = true
-
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/src/pending_future/count_mode.rs
+++ b/src/pending_future/count_mode.rs
@@ -1,12 +1,11 @@
+use crate::priority::Priority;
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::{
-    cell::RefCell,
-    future::Future,
-    ptr::NonNull,
-    sync::{atomic::AtomicUsize, Arc, Mutex},
-    task::{Context, Poll, Waker},
+    future::Future
+    ,
+    sync::Arc,
+    task::{Context, Poll},
 };
-
-use crate::priority::{self, Priority};
 
 pub fn new_pending_future<F>(priority: Priority, future: F) -> PendingFuture<F>
 where
@@ -20,10 +19,10 @@ pub struct PendingFuture<F: Future + Send + 'static> {
     future: F,
     /// priority of this future
     priority: Priority,
-    /// count of pend
-    pub pend_cnt: Arc<u32>, // track the pending count for test
-    /// count of inserted pend
-    pub inserted_pend_cnt: Arc<u32>,
+    /// count of pendings
+    pub pend_cnt: Arc<AtomicU32>, // track the pending count for test
+    /// count of inserted pendings
+    pub inserted_pend_cnt: Arc<AtomicU32>,
 }
 
 impl<F> PendingFuture<F>
@@ -34,9 +33,9 @@ where
     pub fn new(priority: Priority, future: F) -> Self {
         Self {
             future,
-            pend_cnt: Arc::new(0),
             priority,
-            inserted_pend_cnt: Arc::new(0),
+            pend_cnt: Arc::new(AtomicU32::new(0)),
+            inserted_pend_cnt: Arc::new(AtomicU32::new(0)),
         }
     }
 }
@@ -65,23 +64,20 @@ where
     fn poll(self: std::pin::Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let pend_period = self.priority.fixed_interval_count();
 
-        let mut pendcnt = NonNull::new(&*self.pend_cnt as *const _ as *mut u32).unwrap();
-        let mut inserted_pendcnt =
-            NonNull::new(&*self.inserted_pend_cnt as *const _ as *mut u32).unwrap();
+        let pendcnt = self.pend_cnt.clone();
+        let inserted_pendcnt =
+            self.inserted_pend_cnt.clone();
 
         if let Some(pend_period) = pend_period {
-            unsafe {
-                if (*pendcnt.as_ref() + 1) % pend_period == 0 {
-                    // println!("pending");
-                    *pendcnt.as_mut() += 1;
-                    *inserted_pendcnt.as_mut() += 1;
-
-                    // Register the current task to be woken when the pending period is reached.
-                    let waker = cx.waker().clone();
-                    waker.wake();
-
-                    return Poll::Pending;
-                }
+            let cur_pend_cnt = pendcnt.load(Ordering::Acquire);
+            if (cur_pend_cnt) % pend_period == 0 {
+                // println!("pending");
+                pendcnt.fetch_add(1, Ordering::Release);
+                inserted_pendcnt.fetch_add(1, Ordering::Release);
+                // Register the current task to be woken when the pending period is reached.
+                let waker = cx.waker().clone();
+                waker.wake();
+                return Poll::Pending;
             }
         }
 
@@ -90,10 +86,8 @@ where
         match inner_future.poll(cx) {
             Poll::Ready(r) => Poll::Ready(r),
             Poll::Pending => {
-                unsafe {
-                    // println!("pending");
-                    *pendcnt.as_mut() += 1;
-                }
+                // println!("pending");
+                pendcnt.fetch_add(1, Ordering::Release);
                 Poll::Pending
             }
         }
@@ -102,17 +96,10 @@ where
 
 #[cfg(test)]
 mod tests {
-
-    use std::{
-        collections::HashMap,
-        future,
-        sync::{Arc, Mutex},
-    };
-
     use super::PendingFuture;
     use crate::priority::Priority;
-    use crate::test_effect;
-    use crate::test_pend_cnt;
+    use crate::{test_effect, test_pend_cnt};
+    use std::sync::atomic::Ordering;
 
     async fn hello1() {
         println!("hello1");
@@ -137,7 +124,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_multi_await_no_pend() {
-        let future = PendingFuture::new(crate::priority::Priority::Middle, async {
+        let future = PendingFuture::new(Priority::Middle, async {
             // on stack future
             hello1().await;
             hello2().await;
@@ -154,9 +141,9 @@ mod tests {
         tokio::spawn(async move {
             let _ = future.await;
         })
-        .await
-        .unwrap();
-        assert!(*pend_cnt == 0);
+            .await
+            .unwrap();
+        assert_eq!(0, pend_cnt.load(Ordering::Acquire));
     }
 
     #[tokio::test]

--- a/src/pending_future/count_mode.rs
+++ b/src/pending_future/count_mode.rs
@@ -1,8 +1,7 @@
 use crate::priority::Priority;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::{
-    future::Future
-    ,
+    future::Future,
     sync::Arc,
     task::{Context, Poll},
 };
@@ -65,12 +64,11 @@ where
         let pend_period = self.priority.fixed_interval_count();
 
         let pendcnt = self.pend_cnt.clone();
-        let inserted_pendcnt =
-            self.inserted_pend_cnt.clone();
+        let inserted_pendcnt = self.inserted_pend_cnt.clone();
 
+        let cur_pend_cnt = pendcnt.load(Ordering::Acquire);
         if let Some(pend_period) = pend_period {
-            let cur_pend_cnt = pendcnt.load(Ordering::Acquire);
-            if (cur_pend_cnt) % pend_period == 0 {
+            if (cur_pend_cnt + 1) % pend_period == 0 {
                 // println!("pending");
                 pendcnt.fetch_add(1, Ordering::Release);
                 inserted_pendcnt.fetch_add(1, Ordering::Release);
@@ -141,8 +139,8 @@ mod tests {
         tokio::spawn(async move {
             let _ = future.await;
         })
-            .await
-            .unwrap();
+        .await
+        .unwrap();
         assert_eq!(0, pend_cnt.load(Ordering::Acquire));
     }
 

--- a/src/pending_future/tests.rs
+++ b/src/pending_future/tests.rs
@@ -1,10 +1,10 @@
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::{
     collections::{BTreeMap, HashMap},
     future::Future,
     sync::{atomic::AtomicBool, Arc, Mutex},
     thread,
 };
-use std::sync::atomic::{AtomicU32, Ordering};
 use sysinfo::{Pid, ProcessRefreshKind, RefreshKind};
 
 use crate::priority::{self, Priority};
@@ -175,9 +175,9 @@ macro_rules! def_workloads {
 #[macro_export]
 macro_rules! test_effect {
     ($mode: ident) => {
-        use std::sync::Mutex;
-        use std::sync::Arc;
         use std::sync::atomic::AtomicU32;
+        use std::sync::Arc;
+        use std::sync::Mutex;
         crate::def_workloads!();
 
         type WorkLoadId = u64;
@@ -302,7 +302,8 @@ macro_rules! test_effect {
                 for (time, pend_cnt) in time_collect.iter() {
                     sum += time;
                     count += 1;
-                    sum_pendcnt_per_ms += pend_cnt.load(std::sync::atomic::Ordering::Acquire) as f64 / *time as f64;
+                    sum_pendcnt_per_ms +=
+                        pend_cnt.load(std::sync::atomic::Ordering::Acquire) as f64 / *time as f64;
                 }
                 each_workload_pendcnt_per_ms[i as usize] =
                     sum_pendcnt_per_ms / time_collect.len() as f64;

--- a/src/pending_future/time_mode.rs
+++ b/src/pending_future/time_mode.rs
@@ -1,12 +1,10 @@
-use std::{
-    cell::RefCell,
-    future::Future,
-    ptr::NonNull,
-    sync::{atomic::AtomicUsize, Arc, Mutex},
-    task::{Context, Poll, Waker},
-};
-use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use crate::priority::Priority;
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use std::{
+    future::Future,
+    sync::Arc,
+    task::{Context, Poll},
+};
 
 pub fn new_pending_future<F>(priority: Priority, future: F) -> TimeModePendingFuture<F>
 where
@@ -51,11 +49,9 @@ where
     fn poll(self: std::pin::Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let pend_period = self.priority.fixed_interval_time_ms();
 
-        let mut pendcnt = self.pend_cnt.clone();
-        let mut inserted_pendcnt =
-            self.inserted_pend_cnt.clone();
-        let mut adding_up_time =
-            self.adding_up_time.clone();
+        let pendcnt = self.pend_cnt.clone();
+        let inserted_pendcnt = self.inserted_pend_cnt.clone();
+        let adding_up_time = self.adding_up_time.clone();
 
         // println!("adding_up_time: {}", self.adding_up_time);
 
@@ -89,14 +85,9 @@ where
 
 #[cfg(test)]
 mod tests {
-
     use crate::priority::Priority;
     use crate::test_effect;
-    use crate::test_pend_cnt;
-    use std::{
-        collections::HashMap,
-        sync::{Arc, Mutex},
-    };
+    use std::sync::{Arc, Mutex};
 
     // #[tokio::test]
     // async fn test_pend_cnt() {


### PR DESCRIPTION
This PR introduces some refactor:
- use `Arc<AtomicU32>` instead of `Arc<u32>` to spare some unsafe code. This involves some overhead of atomic ops but we can optimize this once we fond the penalty unaccpetable.
- use pin project for wrapping futures.

